### PR TITLE
Reimplement with `os.scandir` for 2.7x speedup

### DIFF
--- a/git_find_repos.py
+++ b/git_find_repos.py
@@ -1,14 +1,15 @@
-from pathlib import Path
 from typing import Iterable
 import argparse
+import os
+import os.path
 
 
-def is_git_repo(path: Path) -> bool:
-    return (path / ".git").is_dir()
+def is_git_repo(path: str) -> bool:
+    return os.path.isdir(os.path.join(path, ".git"))
 
 
-def find_repos(path: Path) -> Iterable[Path]:
-    for child in path.iterdir():
+def find_repos(path: str) -> Iterable[str]:
+    for child in os.scandir(path):
         if child.is_dir():
             if is_git_repo(child):
                 yield child
@@ -19,8 +20,8 @@ def find_repos(path: Path) -> Iterable[Path]:
 def main() -> None:
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("path", type=Path, nargs="?", default=Path("."))
+    parser.add_argument("path", nargs="?", default=".")
     args = parser.parse_args()
 
     for repo_path in find_repos(args.path):
-        print(repo_path.relative_to(args.path))
+        print(os.path.relpath(repo_path, start=args.path))


### PR DESCRIPTION
This commit reimplements git-find-repos to use `os.scandir` to list directory entries, instead of `pathlib.Path.iterdir`.

Using `os.scandir` significantly increases performance because the `os.DirEntry` objects returned expose file attribute information, when the operating system provides it, without additional system calls. For
example, calling the `is_dir` method does not require an additional system call to be made except in the case of symlinks.

In benchmarking this change in the home directory of my development machine, which contains around 80 Git repositories at various different directory depths, I observe a speedup of 2.7x:

    % hyperfine './git-find-repos-orig $HOME' './git-find-repos-new $HOME'
    Benchmark 1: ./git-find-repos-orig $HOME
      Time (mean ± σ):      2.286 s ±  0.032 s    [User: 1.329 s, System: 0.920 s]
      Range (min … max):    2.256 s …  2.355 s    10 runs

    Benchmark 2: ./git-find-repos-new $HOME
      Time (mean ± σ):     852.1 ms ±  15.0 ms    [User: 259.0 ms, System: 537.1 ms]
      Range (min … max):   826.9 ms … 875.4 ms    10 runs

    Summary
      './git-find-repos-new $HOME' ran
        2.68 ± 0.06 times faster than './git-find-repos-orig $HOME'