### PR TITLE
Support git worktrees

### DIFF
--- a/git_find_repos.py
+++ b/git_find_repos.py
@@ -5,7 +5,7 @@ import os.path
 
 
 def is_git_repo(path: str) -> bool:
-    return os.path.isdir(os.path.join(path, ".git"))
+    return os.path.exists(os.path.join(path, ".git"))
 
 
 def find_repos(path: str) -> Iterable[str]:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from setuptools import setup
 
-
 SOURCE_ROOT = Path(__file__).parent
 README = SOURCE_ROOT / "README.rst"
 


### PR DESCRIPTION
In git worktrees, the `.git` object is a file with a pointer to the main `.git` directory location. The `isdir` check was ignoring it and iterating into the whole repo directory structure 😱 .